### PR TITLE
Fix for array overflow bug

### DIFF
--- a/control/lib/gridinstance.js
+++ b/control/lib/gridinstance.js
@@ -26,8 +26,8 @@ wax.GridInstance = function(grid_tile, formatter, options) {
     instance.gridFeature = function(x, y) {
         if (!(grid_tile && grid_tile.grid)) return;
         if ((y < 0) || (x < 0)) return;
-        if ((Math.floor(y) > tileSize) ||
-            (Math.floor(x) > tileSize)) return;
+        if ((Math.floor(y) >= tileSize) ||
+            (Math.floor(x) >= tileSize)) return;
         // Find the key in the grid. The above calls should ensure that
         // the grid's array is large enough to make this work.
         var key = resolveCode(grid_tile.grid[


### PR DESCRIPTION
In instance.gridFeature occasionally y is set to tileSize (eg 256) but the grid_tile.grid array goes from 0 -> (tileSize-1).

at line 33 of gridinstance.js, this triggers:

Uncaught TypeError: Cannot call method 'charCodeAt' of undefined
