### PR TITLE
Remove interactivity layer events in gmaps and refactor grid url callback

### DIFF
--- a/control/g/interaction.js
+++ b/control/g/interaction.js
@@ -20,19 +20,32 @@ wax.g.interaction = function(map, tilejson, options) {
 
         // This requires wax.Tooltip or similar
         callbacks: options.callbacks || new wax.tooltip(),
-
         clickAction: options.clickAction || 'full',
+        eventHandlers:{},
 
         // Attach listeners to the map
         add: function() {
-            google.maps.event.addListener(map, 'tileloaded',
+            this.eventHandlers.tileloaded = google.maps.event.addListener(map, 'tileloaded',
                 wax.util.bind(this.clearTileGrid, this));
 
-            google.maps.event.addListener(map, 'idle',
+            this.eventHandlers.idle = google.maps.event.addListener(map, 'idle',
                 wax.util.bind(this.clearTileGrid, this));
 
-            google.maps.event.addListener(map, 'mousemove', this.onMove());
-            google.maps.event.addListener(map, 'click', this.click());
+            this.eventHandlers.mousemove = google.maps.event.addListener(map, 'mousemove',
+                this.onMove());
+
+            this.eventHandlers.click = google.maps.event.addListener(map, 'click',
+                this.click());
+
+            return this;
+        },
+
+        // Remove interaction events from the map.
+        remove: function() {
+            google.maps.event.removeListener(this.eventHandlers.tileloaded);
+            google.maps.event.removeListener(this.eventHandlers.idle);
+            google.maps.event.removeListener(this.eventHandlers.mousemove);
+            google.maps.event.removeListener(this.eventHandlers.click);
             return this;
         },
 
@@ -76,9 +89,9 @@ wax.g.interaction = function(map, tilejson, options) {
             var grid = this.getTileGrid();
             for (var i = 0; i < grid.length; i++) {
                 if ((grid[i][0] < evt.pixel.y) &&
-                   ((grid[i][0] + 256) > evt.pixel.y) &&
+                    ((grid[i][0] + 256) > evt.pixel.y) &&
                     (grid[i][1] < evt.pixel.x) &&
-                   ((grid[i][1] + 256) > evt.pixel.x)) {
+                    ((grid[i][1] + 256) > evt.pixel.x)) {
                     tile = grid[i][2];
                     break;
                 }

--- a/control/lib/request.js
+++ b/control/lib/request.js
@@ -25,7 +25,7 @@ wax.request = {
             var that = this;
             this.locks[url] = true;
             reqwest({
-                url: url + '?callback=grid',
+                url: wax.util.addUrlData(url, 'callback=grid'),
                 type: 'jsonp',
                 jsonpCallback: 'callback',
                 success: function(data) {

--- a/control/lib/tilejson.js
+++ b/control/lib/tilejson.js
@@ -3,7 +3,7 @@ if (!wax) var wax = {};
 // A wrapper for reqwest jsonp to easily load TileJSON from a URL.
 wax.tilejson = function(url, callback) {
     reqwest({
-        url: url + '?callback=grid',
+        url: wax.util.addUrlData(url, 'callback=grid'),
         type: 'jsonp',
         jsonpCallback: 'callback',
         success: callback,

--- a/control/lib/util.js
+++ b/control/lib/util.js
@@ -68,7 +68,7 @@ wax.util = {
             parseInt(htmlComputed.marginTop, 10) &&
             !isNaN(parseInt(htmlComputed.marginTop, 10))) {
             top += parseInt(htmlComputed.marginTop, 10);
-        left += parseInt(htmlComputed.marginLeft, 10);
+            left += parseInt(htmlComputed.marginLeft, 10);
         }
 
         return {
@@ -89,14 +89,14 @@ wax.util = {
     // Returns a version of a function that always has the second parameter,
     // `obj`, as `this`.
     bind: function(func, obj) {
-      var args = Array.prototype.slice.call(arguments, 2);
-      return function() {
-        return func.apply(obj, args.concat(Array.prototype.slice.call(arguments)));
-      };
+        var args = Array.prototype.slice.call(arguments, 2);
+        return function() {
+            return func.apply(obj, args.concat(Array.prototype.slice.call(arguments)));
+        };
     },
     // From underscore
     isString: function(obj) {
-      return !!(obj === '' || (obj && obj.charCodeAt && obj.substr));
+        return !!(obj === '' || (obj && obj.charCodeAt && obj.substr));
     },
     // IE doesn't have indexOf
     indexOf: function(array, item) {
@@ -139,9 +139,9 @@ wax.util = {
             var leftMargin = parseInt(htmlComputed.marginLeft, 10) || 0;
             return {
                 x: e.clientX + (doc && doc.scrollLeft || body && body.scrollLeft || 0) -
-                  (doc && doc.clientLeft || body && body.clientLeft || 0) + leftMargin,
+                    (doc && doc.clientLeft || body && body.clientLeft || 0) + leftMargin,
                 y: e.clientY + (doc && doc.scrollTop  || body && body.scrollTop  || 0) -
-                  (doc && doc.clientTop  || body && body.clientTop  || 0) + topMargin
+                    (doc && doc.clientTop  || body && body.clientTop  || 0) + topMargin
             };
         } else if (e.touches && e.touches.length === 1) {
             // Touch browsers
@@ -150,5 +150,37 @@ wax.util = {
                 y: e.touches[0].pageY
             };
         }
+    },
+    // parseUri 1.2.2
+    // Steven Levithan <stevenlevithan.com>
+    parseUri: function(str) {
+        var o = {
+            strictMode: false,
+            key: ["source","protocol","authority","userInfo","user","password","host","port","relative","path","directory","file","query","anchor"],
+            q:   {
+                name:   "queryKey",
+                parser: /(?:^|&)([^&=]*)=?([^&]*)/g
+            },
+            parser: {
+                strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,
+                loose:  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*)(?::([^:@]*))?)?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/
+            }
+        },
+            m   = o.parser[o.strictMode ? "strict" : "loose"].exec(str),
+            uri = {},
+            i   = 14;
+
+        while (i--) uri[o.key[i]] = m[i] || "";
+
+        uri[o.q.name] = {};
+        uri[o.key[12]].replace(o.q.parser, function ($0, $1, $2) {
+            if ($1) uri[o.q.name][$1] = $2;
+        });
+        return uri;
+    },
+    // appends callback onto urls regardless of existing query params
+    addUrlData: function(url, data) {
+        url += (this.parseUri(url).query) ? '&' : '?';
+        return url += data;
     }
 };


### PR DESCRIPTION
Remove interactivity based on the modest maps connector remove function. Allows interactivity to be removed from gmaps and reapplied. 

Also refactored the grid URL callback to allow grid urls with query variables to be used in addition to plain URLs. This is useful for cache-busting the grid.json properly.
