### PR TITLE
Touch event fixes

### DIFF
--- a/control/lib/tooltip.js
+++ b/control/lib/tooltip.js
@@ -79,6 +79,7 @@ wax.tooltip.prototype.click = function(feature, context) {
     // IE compatibility.
     if (close.addEventListener) {
         close.addEventListener('click', closeClick, false);
+        close.addEventListener('touchend', closeClick, false);
     } else if (close.attachEvent) {
         close.attachEvent('onclick', closeClick);
     }

--- a/control/mm/interaction.js
+++ b/control/mm/interaction.js
@@ -158,12 +158,14 @@ wax.mm.interaction = function(map, tilejson, options) {
             // Touch moves invalidate touches
             addEvent(map.parent, 'touchend', onUp);
             addEvent(map.parent, 'touchmove', touchCancel);
+            addEvent(map.parent, 'touchcancel', touchCancel);
         }
     }
 
     function touchCancel() {
         removeEvent(map.parent, 'touchend', onUp);
         removeEvent(map.parent, 'touchmove', onUp);
+        removeEvent(map.parent, 'touchcancel', touchCancel);
         _downLock = false;
     }
 
@@ -178,9 +180,10 @@ wax.mm.interaction = function(map, tilejson, options) {
 
         removeEvent(document.body, 'mouseup', onUp);
 
-        if (map.parent.ontouchend) {
+        if (touchable) {
             removeEvent(map.parent, 'touchend', onUp);
-            removeEvent(map.parent, 'touchmove', _touchCancel);
+            removeEvent(map.parent, 'touchmove', touchCancel);
+            removeEvent(map.parent, 'touchcancel', touchCancel);
         }
 
         if (e.type === 'touchend') {


### PR DESCRIPTION
@tmcw - these are the fixes we've worked through together today. Take a close look at (3) - I added that later.
1. When interaction handlers were attached multiple times, onUp was not removed cleanly
2. New touchcancel event was not considered
3. Close link did not respond to touch events.
