### PR TITLE
Fix multiple interactive maps on one page

### DIFF
--- a/control/g/interaction.js
+++ b/control/g/interaction.js
@@ -2,7 +2,7 @@ wax = wax || {};
 wax.g = wax.g || {};
 
 wax.g.interaction = function() {
-    var dirty = false, _grid;
+    var dirty = false, _grid, map;
 
     function setdirty() { dirty = true; }
 

--- a/control/leaf/interaction.js
+++ b/control/leaf/interaction.js
@@ -2,7 +2,7 @@ wax = wax || {};
 wax.leaf = wax.leaf || {};
 
 wax.leaf.interaction = function() {
-    var dirty = false, _grid;
+    var dirty = false, _grid, map;
 
     function setdirty() { dirty = true; }
 

--- a/control/lib/interaction.js
+++ b/control/lib/interaction.js
@@ -12,6 +12,7 @@ wax.interaction = function() {
         tol = 4,
         grid,
         parent,
+        map,
         tileGrid;
 
     var defaultEvents = {
@@ -163,9 +164,9 @@ wax.interaction = function() {
     interaction.map = function(x) {
         if (!arguments.length) return map;
         map = x;
+        if (attach) attach(map);
         bean.add(parent(), defaultEvents);
         bean.add(parent(), 'touchstart', onDown);
-        if (attach) attach(map);
         return interaction;
     };
 

--- a/control/mm/interaction.js
+++ b/control/mm/interaction.js
@@ -2,7 +2,7 @@ wax = wax || {};
 wax.mm = wax.mm || {};
 
 wax.mm.interaction = function() {
-    var dirty = false, _grid;
+    var dirty = false, _grid, map;
 
     function grid() {
         var zoomLayer = map.getLayerAt(0)

--- a/control/ol/interaction.js
+++ b/control/ol/interaction.js
@@ -2,7 +2,7 @@ wax = wax || {};
 wax.ol = wax.ol || {};
 
 wax.ol.interaction = function() {
-    var dirty = false, _grid;
+    var dirty = false, _grid, map;
 
     function setdirty() { dirty = true; }
 


### PR DESCRIPTION
wax.interaction used `window.map` to pass around the map object, which of course breaks down as soon as there are two interactive maps on one page.

This also fixes a clash if any other global variable is called map
