### PR TITLE
Resolution is hard-coded to 4.

### DIFF
--- a/control/lib/gridmanager.js
+++ b/control/lib/gridmanager.js
@@ -55,8 +55,9 @@ wax.gm = function() {
 
         wax.request.get(gurl, function(err, t) {
             if (err) return callback(err, null);
-            callback(null, wax.gi(t, formatter, {
-                resolution: resolution || 4
+            callback(null, wax.gi(t, {
+                formatter: formatter,
+                resolution: resolution
             }));
         });
         return manager;
@@ -70,6 +71,7 @@ wax.gm = function() {
             manager.formatter(x.formatter);
         }
         if (x.grids) manager.gridUrl(x.grids);
+        if (x.resolution) resolution = x.resolution;
         return manager;
     };
 


### PR DESCRIPTION
Sets gridmanager's internal resolution value based on tilejson value (defaults to 4).
Passes gridmanager options to gridinstance object.
