### PR TITLE
Boxselector is resizable

### DIFF
--- a/control/mm/boxselector.js
+++ b/control/mm/boxselector.js
@@ -83,31 +83,17 @@ wax.mm.boxselector = function(map, tilejson, opts) {
         }
     }
 
-    // Expand boxDiv horizontally to point
-    function horizontalResize(point) {
-        if (point.x < corner.x) {
-            style.left = point.x + 'px';
-        } else {
-            style.left = corner.x + 'px';
-        }
-        style.width = Math.abs(point.x - corner.x) - 2 * borderWidth + 'px';
-    }
-
-    // Expand boxDiv vertically to point
-    function verticalResize(point) {
-        if (point.y < corner.y) {
-            style.top = point.y + 'px';
-        } else {
-            style.top = corner.y + 'px';
-        }
-        style.height = Math.abs(point.y - corner.y) - 2 * borderWidth + 'px';
-    }
-
     function mouseMove(e) {
         var point = getMousePoint(e);
         style.display = 'block';
-        if (horizontal) horizontalResize(point);
-        if (vertical) verticalResize(point);
+        if (horizontal) {
+            style.left = (point.x < corner.x ? point.x : corner.x) + 'px';
+            style.width = Math.abs(point.x - corner.x) - 2 * borderWidth + 'px';
+        }
+        if (vertical) {
+            style.top = (point.y < corner.y ? point.y : corner.y) + 'px';
+            style.height = Math.abs(point.y - corner.y) - 2 * borderWidth + 'px';
+        }
         changeCursor(point, map.parent);
         return MM.cancelEvent(e);
     }

--- a/control/mm/boxselector.js
+++ b/control/mm/boxselector.js
@@ -108,6 +108,7 @@ wax.mm.boxselector = function(map, tilejson, opts) {
         style.display = 'block';
         if (horizontal) horizontalResize(point);
         if (vertical) verticalResize(point);
+        changeCursor(point, map.parent);
         return MM.cancelEvent(e);
     }
 
@@ -133,6 +134,30 @@ wax.mm.boxselector = function(map, tilejson, opts) {
         removeEvent(document, 'mouseup', mouseUp);
 
         map.parent.style.cursor = 'auto';
+    }
+
+    function mouseMoveCursor(e) {
+        changeCursor(getMousePoint(e), boxDiv);
+    }
+
+    // Set resize cursor if mouse is on edge
+    function changeCursor(point, elem) {
+        var TL = {
+                x: parseInt(boxDiv.offsetLeft),
+                y: parseInt(boxDiv.offsetTop)
+            },
+            BR = {
+                x: TL.x + parseInt(boxDiv.offsetWidth),
+                y: TL.y + parseInt(boxDiv.offsetHeight)
+            };
+        // Build cursor style string
+        var prefix = '';
+        if (point.y - TL.y <= edge) prefix = 'n';
+        else if (BR.y - point.y <= edge) prefix = 's';
+        if (point.x - TL.x <= edge) prefix += 'w';
+        else if (BR.x - point.x <= edge) prefix += 'e';
+        if (prefix != '') prefix += '-resize';
+        elem.style.cursor = prefix;
     }
 
     function drawbox(map, e) {
@@ -177,6 +202,7 @@ wax.mm.boxselector = function(map, tilejson, opts) {
 
         addEvent(map.parent, 'mousedown', mouseDown);
         addEvent(boxDiv, 'mousedown', mouseDownResize);
+        addEvent(map.parent, 'mousemove', mouseMoveCursor);
         map.addCallback('drawn', drawbox);
         return this;
     };
@@ -185,6 +211,7 @@ wax.mm.boxselector = function(map, tilejson, opts) {
         map.parent.removeChild(boxDiv);
         removeEvent(map.parent, 'mousedown', mouseDown);
         removeEvent(boxDiv, 'mousedown', mouseDownResize);
+        removeEvent(map.parent, 'mousemove', mouseMoveCursor);
         map.removeCallback('drawn', drawbox);
     };
 


### PR DESCRIPTION
The boxselector can be adjusted by clicking and dragging on edges and corners. Mouseup behavior is the same  as when drawing an original box. Weird behavior when dragging over an edge should also be fixed by this.

Fixes #141
and mapbox/tilemill#889
