### PR TITLE
Google style zoom-scale added to zoomer component.

### DIFF
--- a/control/mm/zoomer.js
+++ b/control/mm/zoomer.js
@@ -1,3 +1,5 @@
+/*jslint browser: true, vars: true, forin: true, white: true, nomen: true, plusplus: true, maxerr: 50, indent: 4 */
+/*global wax: true, bean: false, toString: false */
 wax = wax || {};
 wax.mm = wax.mm || {};
 
@@ -6,7 +8,205 @@ wax.mm = wax.mm || {};
 // Add zoom links, which can be styled as buttons, to a `modestmaps.Map`
 // control. This function can be used chaining-style with other
 // chaining-style controls.
-wax.mm.zoomer = function(map) {
+wax.mm.zoomer = function (map, has_scale) {
+    'use strict';
+
+    // Zoom level scale control.
+    var scale = {
+        el: document.createElement('div'),     // Container element.
+        slider: null,                          // Slider element.
+        levels: [],                            // Notch object element holder.
+        notch_points: [],                      // Points (pixels from top) that represent each notch.
+        min: null,                             // Min zoom level.
+        max: null,                             // Max zoom level.
+        height: null,                          // Container height.
+
+        /**
+         * Setup container and append to parent.
+         */
+        init: function (parent) {
+            this.el.className = "wax-zoom-scale"; // Set class name.
+            wax.u.$(parent).appendChild(this.el); // Append to parent el.
+            return this;
+        },
+
+        /**
+         * This should be called once the map is drawn.
+         * Append elements in the slider container. Basically the notches 
+         * and the slider.
+         */
+        draw: function (map, min_zoom, max_zoom) {
+            // If the min/max zoom is different than it was previously,
+            // or just being set for the first time, make the scale.
+            // This also allows for the scale up update itself if the
+            // min and max zoom are changed. Usually this only happens
+            // once though.
+            if (this.min !== min_zoom || this.max !== max_zoom) {
+                this.min = min_zoom;
+                this.max = max_zoom;
+                this._clear_scale();  // Clear the scale.
+
+                this.el.style.position = "absolute"; // Make absolute.
+
+                // Set a default height/width if none is defined in css.
+                this.height = this.el.offsetHeight || 200;
+                this.width = this.el.offsetWidth || 20;
+
+                // Set css for container.
+                this.el.style.width = this.width + 'px';
+                this.el.style.height = this.height + 'px';
+                this.el.style.zIndex = "100";
+                this.el.style.cursor = "pointer";
+
+                // Append notches to notch container, starting with the 
+                // maximum.
+                var _level = this.max;
+                while (_level >= this.min) {
+                    this.el.appendChild(this._make_notch(_level));
+                    _level--; // Decrement till the min is reached.
+                }
+
+                // Append the slider element.
+                this.el.appendChild(this._make_slider());
+            }
+
+            // Update the scale.
+            this.update(map.coordinate.zoom);
+
+            return this;
+        },
+
+        /**
+         * Called when the map is zoomed so the scale updates itself.
+         */
+        update: function (level) {
+            // Move the slider to its appropriate position on the scale if
+            // the user is not moving it manually.
+            if (!this.slider_pressed) {
+                this.slider.style.top = this._slider_pos_from_level(level) + 'px';
+            }
+            return this;
+        },
+
+        /**
+         * Create notch dom el and add to notch obj.
+         */
+        _make_notch: function (level) {
+            var notch = document.createElement('div'),
+                fixed_padding = this.height / (this.max - this.min),
+                spacing = this.notch_points.length * fixed_padding;
+
+            // Apply css to notch.
+            notch.className = "wax-notch level_" + level;
+            notch.style.zIndex = "0";
+            notch.style.position = "absolute";
+            notch.style.top = spacing+'px';
+            this.levels.unshift(level);
+            this.notch_points.unshift(spacing);
+            return notch;
+        },
+
+        /**
+         * Create slider element.
+         */
+        _make_slider: function () {
+            this.slider = document.createElement('div');
+            this.slider.className = "wax-slider";
+            this.slider.style.position = "absolute";
+            this.slider.style.zIndex = "5";
+            this.slider.style.cursor = "pointer";
+
+            // Get self instance.
+            var that = this;
+            
+            // Get container's position on the page.
+            var slider_offset = wax.mm.zoomer.offset(this.el).top;
+
+            // Set to true when the user clicks the slider.
+            this.slider_pressed = false;
+            
+            // Handles the slider being manually dragged.
+            var sliding = function (evt) {
+                if (that.slider_pressed) {
+                    var offset = evt.clientY - slider_offset, level;
+                    evt.stop();
+                    if (offset >= 0 && offset <= that.height) {
+                        that.slider.style.top = offset + 'px';
+                        level = that._level_from_slider_pos(
+                            wax.mm.zoomer.closest_in_arr(that.notch_points, offset)
+                        );
+                        map.setZoom(level);
+                    }
+                }
+            };
+
+            // Add event listeners for it.
+            bean.add(this.slider, 'mousedown', function(evt) {
+                evt.stop();
+                that.slider_pressed = true;
+            });
+            bean.add(this.el, 'mousedown', function(evt) {
+                evt.stop();
+                that.slider_pressed = true;
+                sliding(evt);
+            });
+            bean.add(document, 'mouseup mouseleave click', function() {
+                that.slider_pressed = false;
+            });
+            bean.add(document, 'mousemove', sliding);
+            return this.slider;
+        },
+        
+        /**
+         * Remove everything from the scale and start fresh.
+         */
+        _clear_scale: function () {
+            this.el.innerHTML = '';
+            this.levels = [];
+            this.notch_points = [];
+            bean.remove(this.el);     // For memory leaks.
+            bean.remove(this.slider); // For memory leaks.
+            bean.remove(document);    // For memory leaks.
+            return this;
+        },
+
+        /**
+         * Returns the position (in pixels) based on a map zoom level.
+         */
+        _slider_pos_from_level: function (level) {
+            var i, len = this.levels.length, pos;
+            for (i = 0; len > i; i++) {
+                if (level === this.levels[i]) {
+                    pos = this.notch_points[i];
+                    break;
+                }
+            }
+            return pos;
+        },
+
+
+        /**
+         * Return the map level for a given slider position. Based on
+         * the positions in the notch_points array.
+         */
+        _level_from_slider_pos: function (pos) {
+            var i, len = this.levels.length, pos_index;
+            for (i = 0; len > i; i++) {
+                if (pos === this.notch_points[i]) {
+                    pos_index = i;
+                    break;
+                }
+            }
+            return this.levels[pos_index];
+        }
+    };
+
+
+    // Create container for zoomer.
+    var zoomer_container = document.createElement('div');
+    zoomer_container.className = 'wax-zoomer';
+
+    // Create zoom in dom el.
     var zoomin = document.createElement('a');
     zoomin.innerHTML = '+';
     zoomin.href = '#';
@@ -19,6 +219,7 @@ wax.mm.zoomer = function(map) {
         map.zoomIn();
     }, false);
 
+    // Create zoom out dom el.
     var zoomout = document.createElement('a');
     zoomout.innerHTML = '-';
     zoomout.href = '#';
@@ -31,9 +232,16 @@ wax.mm.zoomer = function(map) {
         map.zoomOut();
     });
 
+
     var zoomer = {
-        add: function(map) {
-            map.addCallback('drawn', function(map, e) {
+        add: function (map) {
+            map.addCallback('drawn', function (map) {
+                if (has_scale) {
+                    scale.draw(map, map.coordLimits[0].zoom, map.coordLimits[1].zoom)
+                        .update(map.coordinate.zoom); 
+                }
+
+                // Set zoom in/out class.
                 if (map.coordinate.zoom === map.coordLimits[0].zoom) {
                     zoomout.className = 'zoomer zoomout zoomdisabled';
                 } else if (map.coordinate.zoom === map.coordLimits[1].zoom) {
@@ -43,13 +251,86 @@ wax.mm.zoomer = function(map) {
                     zoomout.className = 'zoomer zoomout';
                 }
             });
+
             return this;
         },
         appendTo: function(elem) {
-            wax.u.$(elem).appendChild(zoomin);
-            wax.u.$(elem).appendChild(zoomout);
+            zoomer_container.appendChild(zoomin);
+            zoomer_container.appendChild(zoomout);
+            if (has_scale) {
+                scale.init(zoomer_container);
+            }
+            wax.u.$(elem).appendChild(zoomer_container);
             return this;
         }
     };
     return zoomer.add(map);
+};
+
+/**
+ * Returns the closest value in an array to a given int.
+ * Used for determining which position the slider is closest
+ * to.
+ */
+wax.mm.zoomer.closest_in_arr = function (arr, x) {
+    'use strict';
+    var result, a = wax.mm.zoomer.copy(arr), len = a.length, i, nx;
+    a.sort(function (a, b) {
+         return a - b;
+    });
+    for (i=0; len > i; i++) {
+        if (x >= a[len-1]) {
+           result = a[len-1];
+           break;
+         } else if (a[i] >= x) {
+            nx = a[i-1];
+            if (Math.abs(x - a[i]) < Math.abs(x - nx)) {
+                result = a[i];
+                break;
+            } else if (Math.abs(x - nx) < Math.abs(x - a[i])) {
+                result = nx;
+                break;
+            }            
+        }                
+    }
+    return result;
+};
+
+/**
+ * Utility method for cloning an array or object.
+ */
+wax.mm.zoomer.copy = function (obj) {
+    'use strict';
+    var i, copy, len;
+    if (Object.prototype.toString.call(obj) === "[object Array]") {
+        copy = [];
+        for (i = 0, len = obj.length; i < len; ++i) {
+            copy[i] = wax.mm.zoomer.copy(obj[i]);
+        }
+    } else if (Object.prototype.toString.call(obj) === "[object Object]") {
+        copy = {};
+        for (i in obj) {
+            if (obj.hasOwnProperty(i)) {
+                copy[i] = wax.mm.zoomer.copy(obj[i]);
+            }
+        }
+    } else {
+        copy = obj;
+    }
+    return copy;
+};
+
+/**
+ * Utility method for obtaining an elements position on a page.
+ * Equivalent to jQuery's offset().
+ */
+wax.mm.zoomer.offset = function (element) {
+    'use strict';
+    var coords = { left: 0, top: 0};
+    while (element) {
+        coords.left += element.offsetLeft;
+        coords.top += element.offsetTop;
+        element = element.offsetParent;
+    }
+    return coords;
 };

--- a/control/mm/zoomer.js
+++ b/control/mm/zoomer.js
@@ -1,5 +1,3 @@
-/*jslint browser: true, vars: true, forin: true, white: true, nomen: true, plusplus: true, maxerr: 50, indent: 4 */
-/*global wax: true, bean: false, toString: false */
 wax = wax || {};
 wax.mm = wax.mm || {};
 
@@ -9,7 +7,6 @@ wax.mm = wax.mm || {};
 // control. This function can be used chaining-style with other
 // chaining-style controls.
 wax.mm.zoomer = function (map, has_scale) {
-    'use strict';
 
     // Zoom level scale control.
     var scale = {
@@ -94,10 +91,10 @@ wax.mm.zoomer = function (map, has_scale) {
         _make_notch: function (level) {
             var notch = document.createElement('div'),
                 fixed_padding = this.height / (this.max - this.min),
-                spacing = this.notch_points.length * fixed_padding;
+                spacing = this.notch_points.length*fixed_padding;
 
             // Apply css to notch.
-            notch.className = "wax-notch level_" + level;
+            notch.className = "wax-notch level_"+level;
             notch.style.zIndex = "0";
             notch.style.position = "absolute";
             notch.style.top = spacing+'px';
@@ -120,7 +117,7 @@ wax.mm.zoomer = function (map, has_scale) {
             var that = this;
             
             // Get container's position on the page.
-            var slider_offset = wax.mm.zoomer.offset(this.el).top;
+            var slider_offset = wax.u.offset(this.el).top;
 
             // Set to true when the user clicks the slider.
             this.slider_pressed = false;
@@ -133,7 +130,7 @@ wax.mm.zoomer = function (map, has_scale) {
                     if (offset >= 0 && offset <= that.height) {
                         that.slider.style.top = offset + 'px';
                         level = that._level_from_slider_pos(
-                            wax.mm.zoomer.closest_in_arr(that.notch_points, offset)
+                            wax.mm.zoomer.bisect(that.notch_points, offset)
                         );
                         map.setZoom(level);
                     }
@@ -272,65 +269,12 @@ wax.mm.zoomer = function (map, has_scale) {
  * Used for determining which position the slider is closest
  * to.
  */
-wax.mm.zoomer.closest_in_arr = function (arr, x) {
-    'use strict';
-    var result, a = wax.mm.zoomer.copy(arr), len = a.length, i, nx;
-    a.sort(function (a, b) {
-         return a - b;
-    });
-    for (i=0; len > i; i++) {
-        if (x >= a[len-1]) {
-           result = a[len-1];
-           break;
-         } else if (a[i] >= x) {
-            nx = a[i-1];
-            if (Math.abs(x - a[i]) < Math.abs(x - nx)) {
-                result = a[i];
-                break;
-            } else if (Math.abs(x - nx) < Math.abs(x - a[i])) {
-                result = nx;
-                break;
-            }            
-        }                
+wax.mm.zoomer.bisect = function (a, x) {
+    var closest = null; len = a.length, i = 0;
+    while (i < len) {
+        if (closest == null || Math.abs(a[i] - x) < Math.abs(closest - x))
+            closest = a[i];
+        i++;
     }
-    return result;
-};
-
-/**
- * Utility method for cloning an array or object.
- */
-wax.mm.zoomer.copy = function (obj) {
-    'use strict';
-    var i, copy, len;
-    if (Object.prototype.toString.call(obj) === "[object Array]") {
-        copy = [];
-        for (i = 0, len = obj.length; i < len; ++i) {
-            copy[i] = wax.mm.zoomer.copy(obj[i]);
-        }
-    } else if (Object.prototype.toString.call(obj) === "[object Object]") {
-        copy = {};
-        for (i in obj) {
-            if (obj.hasOwnProperty(i)) {
-                copy[i] = wax.mm.zoomer.copy(obj[i]);
-            }
-        }
-    } else {
-        copy = obj;
-    }
-    return copy;
-};
-
-/**
- * Utility method for obtaining an elements position on a page.
- * Equivalent to jQuery's offset().
- */
-wax.mm.zoomer.offset = function (element) {
-    'use strict';
-    var coords = { left: 0, top: 0};
-    while (element) {
-        coords.left += element.offsetLeft;
-        coords.top += element.offsetTop;
-        element = element.offsetParent;
-    }
-    return coords;
+    return closest;
 };

--- a/theme/controls.css
+++ b/theme/controls.css
@@ -6,30 +6,27 @@ a.wax-fullscreen {
   z-index: 99999;
   }
 
-a.zoomer {
-  text-decoration:none;
-  position:absolute;
-  background-color:#444;
-  color:#fff;
-  line-height:25px;
-  font-size:20px;
-  z-index:99999;
-  text-align:center;
-  width:25px;
-  height:25px;
+.wax-zoomer { position:absolute; z-index:100; top:10px; left:10px; }
+  .wax-zoomer a.zoomer {
+    display:inline-block;
+    text-decoration:none;
+    background-color:#444;
+    color:#fff;
+    line-height:25px;
+    font-size:20px;
+    z-index:99999;
+    text-align:center;
+    width:25px;
+    height:25px;
+    margin:0 4px 0 0;
+    -webkit-border-radius: 3px;
+    -moz-border-radius:    3px;
+    border-radius:         3px;
   }
-
-  a.zoomin {
-    left:5px;
-    }
-
-  a.zoomout {
-    left:35px;
-    }
-
-  a.zoomdisabled {
-    background-color:#333;
-    }
+  .wax-zoomer a.zoomdisabled { background-color:#CCC; }
+  .wax-zoomer .wax-zoom-scale { top:48px; left:0; }
+    .wax-zoomer .wax-zoom-scale .wax-notch { height:1px; width:20px; background:#777; }
+    .wax-zoomer .wax-zoom-scale .wax-slider { height:7px; width:20px; background:#111; }
 
 
 .wax-fullscreen-map {


### PR DESCRIPTION
I had to add this to a project I'm currently working on and thought this might be a nice addition.

I've extended the "zoomer" to have an optional Google-style scale. The scale is added if a second parameter is passed to wax.mm.zoomer. Right now in the example given on the site, a jsonp (tilejson) object is passed in as the second parameter but I didn't see how that was utilized so I used that spot to determine whether or not the scale should show. It's lightweight out of the box, but highly customizable. CSS isn't required, but I've added a bit to show it's capabilities to controls.css. I've also contained the zoomin and zoomout buttons in the wax-zoomer container for greater specificity.

Example:
var zoomer = wax.mm.zoomer(map, true); 

See it in action here:
http://petesaia.com/work/wax-zoom/
