### PR TITLE
Don't trigger a click when dismissing a tooltip

### DIFF
--- a/control/lib/interaction.js
+++ b/control/lib/interaction.js
@@ -89,7 +89,7 @@ wax.interaction = function() {
         _downLock = true;
         _d = wax.u.eventoffset(e);
         if (e.type === 'mousedown') {
-            bean.add(document.body, 'mouseup', onUp);
+            bean.add(document.body, 'click', onUp);
 
         // Only track single-touches. Double-touches will not affect this
         // control


### PR DESCRIPTION
Fixes #203

The onDown used to set onUp to be triggered on mouseup. The problem is that the close button doesn't handle mouseup, which means it won't cancel the event, causing a click event to be triggered (by onUp) when closing a tooltip. You wouldn't want to cancel a mouseup anyways, since that would mess with dragging (it would get stuck on down) as far as I can tell. Triggering onUp on a click should fix this problem.
