### PR TITLE
Tooltip cursor bug

### DIFF
--- a/control/lib/tooltip.js
+++ b/control/lib/tooltip.js
@@ -46,18 +46,14 @@ wax.tooltip = function() {
     }
 
     function on(o) {
-        var content;
+        var content = o.content || o.formatter({ format: 'full' }, o.data);
         if (o.e.type === 'mousemove' || !o.e.type) {
-            if (!popped) {
-                content = o.content || o.formatter({ format: 'teaser' }, o.data);
-                if (!content || content == _currentContent) return;
-                hide();
-                parent.style.cursor = 'pointer';
-                tooltips.push(parent.appendChild(getTooltip(content)));
-                _currentContent = content;
+            if (!content || content == _currentContent) {
+                parent.style.cursor = 'default';
+                return;
             }
+            parent.style.cursor = 'pointer';
         } else {
-            content = o.content || o.formatter({ format: 'full' }, o.data);
             if (!content) {
               if (o.e.type && o.e.type.match(/touch/)) {
                 // fallback possible
@@ -67,7 +63,6 @@ wax.tooltip = function() {
               if (!content) return;
             }
             hide();
-            parent.style.cursor = 'pointer';
             var tt = parent.appendChild(getTooltip(content));
             tt.className += ' wax-popup';
 
@@ -76,6 +71,7 @@ wax.tooltip = function() {
             close.className = 'close';
             close.innerHTML = 'Close';
             popped = true;
+            _currentContent = content;
 
             tooltips.push(tt);
 


### PR DESCRIPTION
**The fix isn't complete**

Cursor should become a pointer while over areas that have tooltips. This pull fixes that behavior in tooltip.js  

There is a small bug that causes it to stop working after a tooltip gets closed. The close button cancels the event to prevent a click, but also cancels wanted stuff. In [interaction.js' onUp()](https://github.com/mapbox/wax/blob/master/control/lib/interaction.js#L109) we want to remove the events and reset the _downLock but not trigger the click.

Since tooltip.js can't directly access the variable, something has to be added to the API. What would be preferred?
