### PR TITLE
Close fix

### DIFF
--- a/control/lib/tooltip.js
+++ b/control/lib/tooltip.js
@@ -79,6 +79,10 @@ wax.tooltip = function() {
 
             tooltips.push(tt);
 
+            bean.add(close, 'touchstart mousedown', function(e) {
+                e.stop();
+            });
+
             bean.add(close, 'click touchend', function closeClick(e) {
                 e.stop();
                 hide();

--- a/testcase/tooltip_cancel.html
+++ b/testcase/tooltip_cancel.html
@@ -1,0 +1,30 @@
+<html>
+  <head>
+    <title>b demo</title>
+    <script src='../ext/modestmaps.min.js' type='text/javascript'></script>
+    <script src='../dist/wax.mm.js' type='text/javascript'></script>
+    <link href='../theme/controls.css' rel='stylesheet' type='text/css' />
+
+<style>
+  #map_canvas {
+    position:absolute;
+    width:800px;
+    height:600px;
+  }
+</style>
+  </head>
+  <body>
+    <div id='map_canvas'></div>
+
+    <script type="text/javascript">
+    wax.tilejson('http://c.tiles.mapbox.com/v3/tmcw.map-2sdcp6um.jsonp', function(tilejson) {
+      map = new MM.Map('map_canvas', new wax.mm.connector(tilejson));
+      map.setCenterZoom(new MM.Location(tilejson.center[1], tilejson.center[0]), tilejson.center[2] + 3);
+      inter = wax.mm.interaction()
+          .map(map)
+          .tilejson(tilejson)
+          .on(wax.tooltip().parent(map.parent).animate(true).events());
+    });
+</script>
+  </div>
+</body>


### PR DESCRIPTION
This prevents the downLock of the interaction control from being triggered by clicking on the close button of a tooltip. To do this, it also wipes out the mousedown event on the tooltip - prevents it from bubbling to the map.
