### PR TITLE
Fix interactivity when base layer has no tiles

### DIFF
--- a/control/mm/interaction.js
+++ b/control/mm/interaction.js
@@ -12,18 +12,13 @@ wax.mm.interaction = function() {
         if (!dirty && _grid !== undefined && _grid.length) {
             return _grid;
         } else {
-            var tiles, notempty;
+            var tiles;
             for (var i = 0; i < map.getLayers().length; i++) {
-                tiles = map.getLayerAt(i).tiles;
-                for (var p in tiles) {
-                    notempty = true;
-                    break;
+                var zoomLayer = map.getLayerAt(i).levels[Math.round(map.zoom())];
+                if (zoomLayer !== undefined) {
+                    tiles = map.getLayerAt(i).tileElementsInLevel(zoomLayer);
+                    if (tiles.length) break;
                 }
-                if (notempty) {
-                    var zoomLayer = map.getLayerAt(i)
-                        .levels[Math.round(map.getZoom())];
-                   break;
-               }
             }
             _grid = (function(t) {
                 var o = [];

--- a/control/mm/interaction.js
+++ b/control/mm/interaction.js
@@ -9,11 +9,22 @@ wax.mm.interaction = function() {
             'extentset', 'resized', 'drawn'];
 
     function grid() {
-        var zoomLayer = map.getLayerAt(0)
-            .levels[Math.round(map.getZoom())];
         if (!dirty && _grid !== undefined && _grid.length) {
             return _grid;
         } else {
+            var tiles, notempty;
+            for (var i = 0; i < map.getLayers().length; i++) {
+                tiles = map.getLayerAt(i).tiles;
+                for (var p in tiles) {
+                    notempty = true;
+                    break;
+                }
+                if (notempty) {
+                    var zoomLayer = map.getLayerAt(i)
+                        .levels[Math.round(map.getZoom())];
+                   break;
+               }
+            }
             _grid = (function(t) {
                 var o = [];
                 for (var key in t) {
@@ -27,7 +38,7 @@ wax.mm.interaction = function() {
                     }
                 }
                 return o;
-            })(map.getLayerAt(0).tiles);
+            })(tiles);
             return _grid;
         }
     }


### PR DESCRIPTION
When base layer had no tiles, grid would be empty breaking interactivity. Now it iterates through layers looking for a layer with tiles. Is there a nicer way to check if an object (tiles in this case) is empty?
