### PR TITLE
Open location links in 'top' window by default.

### DIFF
--- a/control/lib/location.js
+++ b/control/lib/location.js
@@ -10,7 +10,7 @@ wax.location = function() {
         } else {
             var loc = o.formatter({ format: 'location' }, o.data);
             if (loc) {
-                window.location.href = loc;
+                window.top.location.href = loc;
             }
         }
     }


### PR DESCRIPTION
Allows the links to bust out of iframes.
