### PR TITLE
Fullscreen fix for relative size maps

### DIFF
--- a/control/mm/fullscreen.js
+++ b/control/mm/fullscreen.js
@@ -12,7 +12,7 @@ wax.mm.fullscreen = function() {
         a = document.createElement('a'),
         map,
         body = document.body,
-        smallSize;
+        dimensions;
 
     a.className = 'map-fullscreen';
     a.href = '#fullscreen';
@@ -50,10 +50,11 @@ wax.mm.fullscreen = function() {
 
     fullscreen.full = function() {
         if (fullscreened) { return; } else { fullscreened = true; }
-        smallSize = [map.parent.offsetWidth, map.parent.offsetHeight];
+        dimensions = map.dimensions;
         map.parent.className += ' map-fullscreen-map';
         body.className += ' map-fullscreen-view';
-        map.setSize({ x: map.parent.offsetWidth, y: map.parent.offsetHeight });
+        map.dimensions = { x: map.parent.offsetWidth, y: map.parent.offsetHeight };
+        map.draw();
         return fullscreen;
     };
 
@@ -61,7 +62,8 @@ wax.mm.fullscreen = function() {
         if (!fullscreened) { return; } else { fullscreened = false; }
         map.parent.className = map.parent.className.replace(' map-fullscreen-map', '');
         body.className = body.className.replace(' map-fullscreen-view', '');
-        map.setSize({ x: smallSize[0], y: smallSize[1] });
+        map.dimensions = dimensions;
+        map.draw();
         return fullscreen;
     };
 


### PR DESCRIPTION
Original report: 

> I've run into an issue where a map div's dimensions are initially defined using relative units (e.g. width:50%). Once it goes into fullscreen mode and back the control sets its parent's dimensions explicitly using absolute units (e.g. 493px) based on the size of the window at the time meaning any further window resizes tend to break the intended layout of the page.

It looks like this should fix it. Do you see this breaking anything?
