### PR TITLE
hasOwnProperty in _grid function in wax.mm.interaction

### DIFF
--- a/control/mm/interaction.js
+++ b/control/mm/interaction.js
@@ -24,7 +24,7 @@ wax.mm.interaction = function() {
             _grid = (function(t) {
                 var o = [];
                 for (var key in t) {
-                    if (t[key].parentNode === zoomLayer) {
+                    if (t.hasOwnProperty(key) && t[key].parentNode === zoomLayer) {
                         var offset = wax.u.offset(t[key]);
                         o.push([
                             offset.top,


### PR DESCRIPTION
when using for in with libraries that modify Object.prototype this
causes erroneous keys to be attempted, note that there are other places
in the code with similar for in statements that may produce errors as
well
