### PR TITLE
Prep leaf.connector tilejson bounds for L.LatLngBounds.

### DIFF
--- a/connectors/leaf/connector.js
+++ b/connectors/leaf/connector.js
@@ -4,6 +4,12 @@ wax.leaf = wax.leaf || {};
 wax.leaf.connector = L.TileLayer.extend({
     initialize: function(options) {
         options = options || {};
+        if (options.bounds) {
+          options.bounds = [
+            [options.bounds[1], options.bounds[0]],
+            [options.bounds[3], options.bounds[2]]
+          ]
+        }
         options.minZoom = options.minzoom || 0;
         options.maxZoom = options.maxzoom || 22;
         L.TileLayer.prototype.initialize.call(this, options.tiles[0], options);


### PR DESCRIPTION
L.TileLayer in Leaflet master (0.6-dev) now parses bounds by instantiating L.LatLngBounds from options.bounds. Passing the bbox array in errors out.

http://leafletjs.com/reference.html#latlngbounds
